### PR TITLE
Acceptance of query types in required arguments

### DIFF
--- a/disqusapi/disqusapi.php
+++ b/disqusapi/disqusapi.php
@@ -189,9 +189,13 @@ class DisqusData extends ArrayIterator {
      * http://groups.google.com/group/disqus-dev/browse_thread/thread/0fb42bafb74ee663?pli=1
      */
     public function __get($name) {
-        //if (isset($this->$name)) {
+        if (isset($this->$name)) {
             return $this->$name;
-        //}
+        }
+        // Provide support for single data only response (one row) access.
+        if (isset($this[$name])) {
+          return $this[$name];
+        }
     }
 }
 

--- a/disqusapi/disqusapi.php
+++ b/disqusapi/disqusapi.php
@@ -108,10 +108,10 @@ class DisqusResource {
             }
         }
 
-	if (!empty($missing)) {
-	    throw new Exception('Missing required argument(s): ' .join(', ', $missing));
-	}
-	unset($missing, $k, $ek);
+        if (!empty($missing)) {
+            throw new Exception('Missing required argument(s): ' .join(', ', $missing));
+        }
+        unset($missing, $k, $ek);
         
         $api = $this->api;
         
@@ -145,10 +145,51 @@ class DisqusResource {
             throw new DisqusAPIError($data->code, $data->response);
         }
         
-        return $data->response;
+        return new DisqusData($data);
     }
 }
 
+/*
+ * The API response data will be accessiable as it was before, but you will now also be able to 
+ * access the cursor information and code.
+ * 
+ * 
+    $posts = $disqus->posts->list(array('limit' => 10));
+  
+    // Same syntax to access the data as before
+    foreach ($posts as $post) {
+        echo $post->id, ' by ', $post->author->name, PHP_EOL;
+    }
+    // or
+    echo $posts[2]->author->name, PHP_EOL;
+  
+    // New
+    print_r($posts->cursor);
+    echo $posts->code;
+ */
+class DisqusData extends ArrayIterator {
+  
+    protected $cursor = array();
+    protected $code = -1;
+
+    public function __construct($data) {       
+        // Keep BC, so we give only the response part to ArrayIterator
+        parent::__construct($data->response);
+        
+        $this->cursor = $data->cursor;
+        $this->code = $data->code;
+    }
+    
+    /*
+     * Not via get*() methods to keep with the syntax specified here:
+     * http://groups.google.com/group/disqus-dev/browse_thread/thread/0fb42bafb74ee663?pli=1
+     */
+    public function __get($name) {
+        //if (isset($this->$name)) {
+            return $this->$name;
+        //}
+    }
+}
 
 class DisqusAPI extends DisqusResource {
     public $formats = array(

--- a/disqusapi/disqusapi.php
+++ b/disqusapi/disqusapi.php
@@ -107,6 +107,11 @@ class DisqusResource {
 		}
 	    }
         }
+
+	if (!empty($missing)) {
+	    throw new Exception('Missing required argument(s): ' .join(', ', $missing));
+	}
+	unset($missing, $k, $ek);
         
         $api = $this->api;
         

--- a/disqusapi/disqusapi.php
+++ b/disqusapi/disqusapi.php
@@ -80,32 +80,32 @@ class DisqusResource {
         }
         $kwargs = (array)$args[0];
         
-	foreach ((array) $resource->required as $k) {
-	    if (empty($kwargs[$k])) {
-		// Check if query types are available, and we have one we can override
-		if ($resource->query_type && $resource->query_type->insteadof == $k) {
-		    if (empty($kwargs[$resource->query_type->requires])) {
-			$missing[] = $k .  ' or ' . $resource->query_type->requires;
-		    } else {
-			// Check for other required args to make up the query type ..
-			$missing_or = array();
-			foreach ((array) $resource->query_type->with_either as $ek) {
-			    if (isset($kwargs[$ek])) {
-				// Now must have everything needed for the query
-				break;
-			    } else {
-				$missing_or[] = $ek;
-			    }
-			}
-			if (!empty($missing_or)) {
-			    $missing[] = join(' or ', $missing_or);
-			}
-			unset($missing_or);
-		    }
-		} else {
-		    $missing[] = $k;
-		}
-	    }
+        foreach ((array) $resource->required as $k) {
+            if (empty($kwargs[$k])) {
+                // Check if query types are available, and we have one we can override
+                if ($resource->query_type && $resource->query_type->insteadof == $k) {
+                    if (empty($kwargs[$resource->query_type->requires])) {
+                        $missing[] = $k .  ' or ' . $resource->query_type->requires;
+                    } else {
+                        // Check for other required args to make up the query type ..
+                        $missing_or = array();
+                        foreach ((array) $resource->query_type->with_either as $ek) {
+                            if (isset($kwargs[$ek])) {
+                                // Now must have everything needed for the query
+                                break;
+                            } else {
+                                $missing_or[] = $ek;
+                            }
+                        }
+                        if (!empty($missing_or)) {
+                            $missing[] = join(' or ', $missing_or);
+                        }
+                        unset($missing_or);
+                    }
+                } else {
+                    $missing[] = $k;
+                }
+            }
         }
 
 	if (!empty($missing)) {

--- a/disqusapi/disqusapi.php
+++ b/disqusapi/disqusapi.php
@@ -176,8 +176,12 @@ class DisqusData extends ArrayIterator {
         // Keep BC, so we give only the response part to ArrayIterator
         parent::__construct($data->response);
         
-        $this->cursor = $data->cursor;
-        $this->code = $data->code;
+        if (isset($data->cursor)) {
+          $this->cursor = $data->cursor;
+        }
+        if (isset($data->code)) {
+          $this->code = $data->code;
+        }
     }
     
     /*

--- a/disqusapi/disqusapi.php
+++ b/disqusapi/disqusapi.php
@@ -80,10 +80,32 @@ class DisqusResource {
         }
         $kwargs = (array)$args[0];
         
-        foreach ((array)$resource->required as $k) {
-            if (empty($kwargs[$k])) {
-                throw new Exception('Missing required argument: '.$k);
-            }
+	foreach ((array) $resource->required as $k) {
+	    if (empty($kwargs[$k])) {
+		// Check if query types are available, and we have one we can override
+		if ($resource->query_type && $resource->query_type->insteadof == $k) {
+		    if (empty($kwargs[$resource->query_type->requires])) {
+			$missing[] = $k .  ' or ' . $resource->query_type->requires;
+		    } else {
+			// Check for other required args to make up the query type ..
+			$missing_or = array();
+			foreach ((array) $resource->query_type->with_either as $ek) {
+			    if (isset($kwargs[$ek])) {
+				// Now must have everything needed for the query
+				break;
+			    } else {
+				$missing_or[] = $ek;
+			    }
+			}
+			if (!empty($missing_or)) {
+			    $missing[] = join(' or ', $missing_or);
+			}
+			unset($missing_or);
+		    }
+		} else {
+		    $missing[] = $k;
+		}
+	    }
         }
         
         $api = $this->api;

--- a/disqusapi/disqusapi.php
+++ b/disqusapi/disqusapi.php
@@ -108,10 +108,10 @@ class DisqusResource {
             }
         }
 
-	if (!empty($missing)) {
-	    throw new Exception('Missing required argument(s): ' .join(', ', $missing));
-	}
-	unset($missing, $k, $ek);
+        if (!empty($missing)) {
+            throw new Exception('Missing required argument(s): ' .join(', ', $missing));
+        }
+        unset($missing, $k, $ek);
         
         $api = $this->api;
         

--- a/disqusapi/interfaces.json
+++ b/disqusapi/interfaces.json
@@ -3,607 +3,637 @@
     "list": {
       "required": [
         "forum"
-      ], 
-      "method": "POST", 
+      ],
+      "method": "POST",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "details": {
       "required": [
         "reaction"
-      ], 
-      "method": "GET", 
+      ],
+      "method": "GET",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
     }
-  }, 
+  },
   "exports": {
     "exportForum": {
       "required": [
         "forum"
-      ], 
-      "method": "POST", 
+      ],
+      "method": "POST",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
     }
-  }, 
+  },
   "users": {
     "listActiveForums": {
-      "required": [], 
-      "method": "GET", 
+      "required": [],
+      "method": "GET",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "listFollowing": {
-      "required": [], 
-      "method": "GET", 
+      "required": [],
+      "method": "GET",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "listForums": {
-      "required": [], 
-      "method": "GET", 
+      "required": [],
+      "method": "GET",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "unfollow": {
-      "required": [], 
-      "method": "POST", 
+      "required": [],
+      "method": "POST",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "details": {
-      "required": [], 
-      "method": "GET", 
+      "required": [],
+      "method": "GET",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "listFollowers": {
-      "required": [], 
-      "method": "GET", 
+      "required": [],
+      "method": "GET",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "follow": {
-      "required": [], 
-      "method": "POST", 
+      "required": [],
+      "method": "POST",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "listActivity": {
-      "required": [], 
-      "method": "GET", 
+      "required": [],
+      "method": "GET",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "listMostActiveForums": {
-      "required": [], 
-      "method": "GET", 
+      "required": [],
+      "method": "GET",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
     }
-  }, 
+  },
   "imports": {
     "list": {
       "required": [
         "forum"
-      ], 
-      "method": "GET", 
+      ],
+      "method": "GET",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "details": {
       "required": [
         "group"
-      ], 
-      "method": "GET", 
+      ],
+      "method": "GET",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
     }
-  }, 
+  },
   "posts": {
     "restore": {
       "required": [
         "post"
-      ], 
-      "method": "POST", 
+      ],
+      "method": "POST",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "search": {
       "required": [
         "query"
-      ], 
-      "method": "GET", 
+      ],
+      "method": "GET",
       "formats": [
-        "json", 
-        "jsonp", 
+        "json",
+        "jsonp",
         "rss"
       ]
-    }, 
+    },
     "spam": {
       "required": [
         "post"
-      ], 
-      "method": "POST", 
+      ],
+      "method": "POST",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "approve": {
       "required": [
         "post"
-      ], 
-      "method": "POST", 
+      ],
+      "method": "POST",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "create": {
       "required": [
         "message"
-      ], 
-      "method": "POST", 
+      ],
+      "method": "POST",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "list": {
-      "required": [], 
-      "method": "GET", 
+      "required": [],
+      "method": "GET",
       "formats": [
-        "json", 
-        "jsonp", 
+        "json",
+        "jsonp",
         "rss"
       ]
-    }, 
+    },
     "remove": {
       "required": [
         "post"
-      ], 
-      "method": "POST", 
+      ],
+      "method": "POST",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "vote": {
       "required": [
-        "vote", 
+        "vote",
         "post"
-      ], 
-      "method": "POST", 
+      ],
+      "method": "POST",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "details": {
       "required": [
         "post"
-      ], 
-      "method": "GET", 
+      ],
+      "method": "GET",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "report": {
       "required": [
         "post"
-      ], 
-      "method": "POST", 
+      ],
+      "method": "POST",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "listPopular": {
-      "required": [], 
-      "method": "GET", 
+      "required": [],
+      "method": "GET",
       "formats": [
-        "json", 
-        "jsonp", 
+        "json",
+        "jsonp",
         "rss"
       ]
     }
-  }, 
+  },
   "blacklists": {
     "add": {
       "required": [
         "forum"
-      ], 
-      "method": "POST", 
+      ],
+      "method": "POST",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "list": {
       "required": [
         "forum"
-      ], 
-      "method": "GET", 
+      ],
+      "method": "GET",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "remove": {
       "required": [
         "forum"
-      ], 
-      "method": "POST", 
+      ],
+      "method": "POST",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
     }
-  }, 
+  },
   "reports": {
     "domains": {
-      "required": [], 
-      "method": "GET", 
+      "required": [],
+      "method": "GET",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "ips": {
-      "required": [], 
-      "method": "GET", 
+      "required": [],
+      "method": "GET",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "threads": {
-      "required": [], 
-      "method": "GET", 
+      "required": [],
+      "method": "GET",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "users": {
-      "required": [], 
-      "method": "GET", 
+      "required": [],
+      "method": "GET",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
     }
-  }, 
+  },
   "whitelists": {
     "add": {
       "required": [
         "forum"
-      ], 
-      "method": "POST", 
+      ],
+      "method": "POST",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "list": {
       "required": [
         "forum"
-      ], 
-      "method": "GET", 
+      ],
+      "method": "GET",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "remove": {
       "required": [
         "forum"
-      ], 
-      "method": "POST", 
+      ],
+      "method": "POST",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
     }
-  }, 
+  },
   "applications": {
     "listUsage": {
-      "required": [], 
-      "method": "GET", 
+      "required": [],
+      "method": "GET",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
     }
-  }, 
+  },
   "trends": {
     "listThreads": {
-      "required": [], 
-      "method": "GET", 
+      "required": [],
+      "method": "GET",
       "formats": [
-        "json", 
-        "jsonp", 
+        "json",
+        "jsonp",
         "rss"
       ]
     }
-  }, 
+  },
   "threads": {
     "restore": {
       "required": [
         "thread"
-      ], 
-      "method": "POST", 
+      ],
+      "query_type": {
+          "requires": "forum",
+          "insteadof": "thread",
+          "with_either": ["thread:ident", "thread:link" ]
+        },
+      "method": "POST",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "vote": {
       "required": [
-        "thread", 
+        "thread",
         "vote"
-      ], 
-      "method": "POST", 
+      ],
+      "query_type": {
+          "requires": "forum",
+          "insteadof": "thread",
+          "with_either": ["thread:ident", "thread:link" ]
+        },
+      "method": "POST",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "create": {
       "required": [
-        "forum", 
+        "forum",
         "title"
-      ], 
-      "method": "POST", 
+      ],
+      "method": "POST",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "list": {
-      "required": [], 
-      "method": "GET", 
+      "required": [],
+      "method": "GET",
       "formats": [
-        "json", 
-        "jsonp", 
+        "json",
+        "jsonp",
         "rss"
       ]
-    }, 
+    },
     "listMostLiked": {
-      "required": [], 
-      "method": "GET", 
+      "required": [],
+      "method": "GET",
       "formats": [
-        "json", 
-        "jsonp", 
+        "json",
+        "jsonp",
         "rss"
       ]
-    }, 
+    },
     "listHot": {
-      "required": [], 
-      "method": "GET", 
+      "required": [],
+      "method": "GET",
       "formats": [
-        "json", 
-        "jsonp", 
+        "json",
+        "jsonp",
         "rss"
       ]
-    }, 
+    },
     "update": {
       "required": [
         "thread"
-      ], 
-      "method": "POST", 
+      ],
+      "method": "POST",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "listSimilar": {
       "required": [
         "thread"
-      ], 
-      "method": "GET", 
+      ],
+      "method": "GET",
       "formats": [
-        "json", 
-        "jsonp", 
+        "json",
+        "jsonp",
         "rss"
       ]
-    }, 
+    },
     "details": {
       "required": [
         "thread"
-      ], 
-      "method": "GET", 
+      ],
+      "query_type": {
+          "requires": "forum",
+          "insteadof": "thread",
+          "with_either": ["thread:ident", "thread:link" ]
+        },
+      "method": "GET",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "listByDate": {
-      "required": [], 
-      "method": "GET", 
+      "required": [],
+      "method": "GET",
       "formats": [
-        "json", 
-        "jsonp", 
+        "json",
+        "jsonp",
         "rss"
       ]
-    }, 
+    },
     "listPosts": {
       "required": [
         "thread"
-      ], 
-      "method": "GET", 
+      ],
+      "method": "GET",
       "formats": [
-        "json", 
-        "jsonp", 
+        "json",
+        "jsonp",
         "rss"
       ]
-    }, 
+    },
     "close": {
       "required": [
         "thread"
-      ], 
-      "method": "POST", 
+      ],
+      "query_type": {
+          "requires": "forum",
+          "insteadof": "thread",
+          "with_either": ["thread:ident", "thread:link" ]
+        },
+      "method": "POST",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "remove": {
       "required": [
         "thread"
-      ], 
-      "method": "POST", 
+      ],
+      "query_type": {
+          "requires": "forum",
+          "insteadof": "thread",
+          "with_either": ["thread:ident", "thread:link" ]
+        },
+      "method": "POST",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "open": {
       "required": [
         "thread"
-      ], 
-      "method": "POST", 
+      ],
+      "query_type": {
+          "requires": "forum",
+          "insteadof": "thread",
+          "with_either": ["thread:ident", "thread:link" ]
+        },
+      "method": "POST",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
     }
-  }, 
+  },
   "forums": {
     "listCategories": {
       "required": [
         "forum"
-      ], 
-      "method": "GET", 
+      ],
+      "method": "GET",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "listThreads": {
       "required": [
         "forum"
-      ], 
-      "method": "GET", 
+      ],
+      "method": "GET",
       "formats": [
-        "json", 
-        "jsonp", 
+        "json",
+        "jsonp",
         "rss"
       ]
-    }, 
+    },
     "listUsers": {
       "required": [
         "forum"
-      ], 
-      "method": "GET", 
+      ],
+      "method": "GET",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "listMostLikedUsers": {
       "required": [
         "forum"
-      ], 
-      "method": "GET", 
+      ],
+      "method": "GET",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "details": {
       "required": [
         "forum"
-      ], 
-      "method": "GET", 
+      ],
+      "method": "GET",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "listPosts": {
       "required": [
         "forum"
-      ], 
-      "method": "GET", 
+      ],
+      "method": "GET",
       "formats": [
-        "json", 
-        "jsonp", 
+        "json",
+        "jsonp",
         "rss"
       ]
     }
-  }, 
+  },
   "categories": {
     "listPosts": {
       "required": [
         "category"
-      ], 
-      "method": "GET", 
+      ],
+      "method": "GET",
       "formats": [
-        "json", 
-        "jsonp", 
+        "json",
+        "jsonp",
         "rss"
       ]
-    }, 
+    },
     "listThreads": {
       "required": [
         "category"
-      ], 
-      "method": "GET", 
+      ],
+      "method": "GET",
       "formats": [
-        "json", 
-        "jsonp", 
+        "json",
+        "jsonp",
         "rss"
       ]
-    }, 
+    },
     "list": {
-      "required": [], 
-      "method": "GET", 
+      "required": [],
+      "method": "GET",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
-    }, 
+    },
     "details": {
       "required": [
         "category"
-      ], 
-      "method": "GET", 
+      ],
+      "method": "GET",
       "formats": [
-        "json", 
+        "json",
         "jsonp"
       ]
     }

--- a/disqusapi/interfaces.json
+++ b/disqusapi/interfaces.json
@@ -502,6 +502,15 @@
         "rss"
       ]
     },
+    "listPopular": {
+      "required": [],
+      "method": "GET",
+      "formats": [
+        "json",
+        "jsonp",
+        "rss"
+      ]
+    },
     "update": {
       "required": [
         "thread"


### PR DESCRIPTION
So now you can use:

$data = array('forum' => 'forum_name', 'thread:ident' => 'ident');

json configuration feels a little clunky, but does its job.

"details": {
      "required": [
        "thread"
      ],
      "query_type": {
          "requires": "forum",
          "insteadof": "thread",
          "with_either": ["thread:ident", "thread:link" ]
        },
      "method": "GET", 
      "formats": [
        "json", 
        "jsonp"
      ]
    },

I have only updated the configuration for the threads commands (not sure if anything else is missing).
