### PR TITLE
Minor change that allows arrays to be given as arguments in Disqus calls, in addition to strings.

### DIFF
--- a/disqusapi/url.php
+++ b/disqusapi/url.php
@@ -7,7 +7,14 @@ function dsq_get_query_string($postdata) {
 
     if($postdata) {
         foreach($postdata as $key=>$value) {
-            $postdata_str .= urlencode($key) . '=' . urlencode($value) . '&';
+            if (!is_array($value)) {
+                $postdata_str .= urlencode($key) . '=' . urlencode($value) . '&';
+            } else {
+                // if the item is an array, expands it so that the 'allows multiple' API option can work
+                foreach($value as $multipleValue) {
+                    $postdata_str .= urlencode($key) . '=' . urlencode($multipleValue) . '&';
+                }
+            }
         }
     }
 


### PR DESCRIPTION
With this change, arrays are treated as multiple values for the same argument, to be used with Disqus method arguments that allow for multiple values. Such method arguments are marked in the API docs with 'allows multiple'.

I could not find an existing way to pass multiple values for the same argument using the PHP API, so I made this change. In any case, the change is fairly intuitive I think.

E.g.
"thread" : array("1234", "2345")

is unrolled as "&thread=1234&thread=2345"

I had previously submitted this pull request – it is redone using the same whitespace options that Disqus uses.
