### PR TITLE
Added support for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "drexarj/disqus-php",
+    "license": "Apache-2.0",
+    "type": "project",
+    "description": "The official PHP client library for disqus, with added composer.json.",
+    "autoload": {
+        "classmap": { "": "disqusapi/" }
+    },
+    "require": {
+        "php": ">=5.3.0"
+    },
+    "minimum-stability": "stable"
+}


### PR DESCRIPTION
Composer is a dependency manager for PHP that is highly used among developers and their libraries. http://getcomposer.org/

This commit adds support for composer packaging for this library.

Please take notice that after accepting this pull request Disqus have to officially add the library in Packagist.
https://packagist.org/packages/submit

Signed-off-by: Alex Rico alex@openhost.es
