### PR TITLE
Updating disqusapi.php to return full response

### DIFF
--- a/disqusapi/disqusapi.php
+++ b/disqusapi/disqusapi.php
@@ -115,7 +115,7 @@ class DisqusResource {
             throw new DisqusAPIError($data->code, $data->response);
         }
 
-        return $data->response;
+        return $data;
     }
 }
 


### PR DESCRIPTION
This library currently does not support returning the cursor, nor is it architected in a way that easily lets you assign the cursor as a field.  Altered the library to return the full response so pagination can be used.
