### PR TITLE
Fix warning in DisqusResource->__call() method

### DIFF
--- a/disqusapi/disqusapi.php
+++ b/disqusapi/disqusapi.php
@@ -75,7 +75,7 @@ class DisqusResource {
         if (!$resource) {
             throw new DisqusInterfaceNotDefined();
         }
-        $kwargs = (array)$args[0];
+        $kwargs = isset($args[0]) ? (array)$args[0] : array();
 
         foreach ((array)$resource->required as $k) {
             if (empty($kwargs[$k])) {


### PR DESCRIPTION
Add a check to ensure `$args` has an element at index 0 before accessing it in the `__call` method of the `DisqusResource` class.

* Modify line 78 in `disqusapi/disqusapi.php` to check if `$args` has an element at index 0 before accessing it.
